### PR TITLE
Decouple lead state handling

### DIFF
--- a/modules/e2e_tests/src/tests/LeadService/LeadClose.e2e.test.ts
+++ b/modules/e2e_tests/src/tests/LeadService/LeadClose.e2e.test.ts
@@ -6,9 +6,11 @@ import { LEAD_SERVICE_NAME } from "../../globalSetup";
 import { TEST_API_KEY, supertest } from "../../setup";
 const leadId = uuidv4();
 const testLead = {
+	SchemaVersion: "2.0.0",
 	UniversalRetailerId: uuidv4(),
-	LocationId: uuidv4(),
+	LeadType: "WEB2TEXT",
 	Lead: {
+		LocationId: uuidv4(),
 		PageUrl: "https://example.com",
 		IPAddress: "192.168.1.1",
 		Name: "John Doe",
@@ -43,12 +45,12 @@ describe("Lead Close E2E Tests", () => {
 
 		nock(process.env.NEXUS_AWS_API_URL!)
 			.get("/nexus/location")
-			.query({ location_id: testLead.LocationId })
+			.query({ location_id: testLead.Lead.LocationId })
 			.reply(200, {
 				data: [
 					{
-						id: testLead.LocationId,
-						location_id: testLead.LocationId,
+						id: testLead.Lead.LocationId,
+						location_id: testLead.Lead.LocationId,
 						Web2Text_Phone_Number: "+12246591932",
 					},
 				],

--- a/modules/e2e_tests/src/tests/LeadService/LeadCreation.e2e.test.ts
+++ b/modules/e2e_tests/src/tests/LeadService/LeadCreation.e2e.test.ts
@@ -7,9 +7,11 @@ import { supertest } from "../../setup";
 import { TEST_API_KEY } from "../../setup";
 
 const testLead = {
+	SchemaVersion: "2.0.0",
 	UniversalRetailerId: "314aa161-867a-4902-b780-35c62319b418",
-	LocationId: "d3ff7b23-fe09-4959-85b7-fb08d4bb1cb9",
+	LeadType: "WEB2TEXT",
 	Lead: {
+		LocationId: "d3ff7b23-fe09-4959-85b7-fb08d4bb1cb9",
 		PageUrl: "https://carpetdirect.com/d/some-product/some-sku",
 		IPAddress: "127.0.0.1",
 		Name: "John Smith",
@@ -48,12 +50,12 @@ describe("Lead Creation", () => {
 
 		nock(process.env.NEXUS_AWS_API_URL!)
 			.get("/nexus/location")
-			.query({ location_id: testLead.LocationId })
+			.query({ location_id: testLead.Lead.LocationId })
 			.reply(200, {
 				data: [
 					{
-						id: testLead.LocationId,
-						location_id: testLead.LocationId,
+						id: testLead.Lead.LocationId,
+						location_id: testLead.Lead.LocationId,
 						Web2Text_Phone_Number: "+12246591932",
 					},
 				],
@@ -138,7 +140,7 @@ describe("Lead Creation", () => {
 			.persist();
 		nock(process.env.NEXUS_AWS_API_URL!)
 			.get("/nexus/location")
-			.query({ location_id: testLead.LocationId })
+			.query({ location_id: testLead.Lead.LocationId })
 			.reply(404)
 			.persist();
 		const leadID = randomUUID();
@@ -165,7 +167,7 @@ describe("Lead Creation", () => {
 	test("Lead creation with missing required fields", async () => {
 		const incompleteLead = {
 			UniversalRetailerId: testLead.UniversalRetailerId,
-			LocationId: testLead.LocationId,
+			LocationId: testLead.Lead.LocationId,
 			Lead: {
 				PageUrl: testLead.Lead.PageUrl,
 				IPAddress: testLead.Lead.IPAddress,
@@ -202,12 +204,12 @@ describe("Lead Creation", () => {
 
 		nock(process.env.NEXUS_AWS_API_URL!)
 			.get("/nexus/location")
-			.query({ location_id: testLead.LocationId })
+			.query({ location_id: testLead.Lead.LocationId })
 			.reply(200, {
 				data: [
 					{
-						id: testLead.LocationId,
-						location_id: testLead.LocationId,
+						id: testLead.Lead.LocationId,
+						location_id: testLead.Lead.LocationId,
 						Web2Text_Phone_Number: "+12246591932",
 					},
 				],

--- a/modules/swagger_docs/swagger.json
+++ b/modules/swagger_docs/swagger.json
@@ -857,20 +857,6 @@
               "properties": {
                 "Status": {
                   "type": "string",
-                  "enum": ["VALIDATING"]
-                },
-                "Request": {
-                  "type": "object",
-                  "additionalProperties": true
-                }
-              },
-              "required": ["Status", "Request"]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "Status": {
-                  "type": "string",
                   "enum": ["ERROR"]
                 },
                 "Error": {

--- a/modules/web2text/src/app.ts
+++ b/modules/web2text/src/app.ts
@@ -10,10 +10,10 @@ import {
 } from "common/restate";
 import { LeadStateModel } from "./dynamodb/LeadStateModel";
 import { OptedOutNumberModel } from "./dynamodb/OptedOutNumberModel";
-import { AdminService } from "./restate/services/AdminService";
-import { DealerVirtualObject } from "./restate/services/DealerVirtualObject";
-import { LeadVirtualObject } from "./restate/services/LeadVirtualObject";
-import { TwilioWebhooks } from "./restate/services/TwilioWebhooks";
+import { AdminService } from "./restate/services/Admin/AdminService";
+import { DealerVirtualObject } from "./restate/services/Dealer/DealerVirtualObject";
+import { LeadVirtualObject } from "./restate/services/Lead/LeadVirtualObject";
+import { TwilioWebhooks } from "./restate/services/TwilioWebhooks/TwilioWebhooks";
 import { TWILIO_CLIENT } from "./twilio";
 import { VerifyEnvVariables } from "./verifyEnvVariables";
 

--- a/modules/web2text/src/dynamodb/LeadStateModel.ts
+++ b/modules/web2text/src/dynamodb/LeadStateModel.ts
@@ -7,9 +7,9 @@ import type { Web2TextLead } from "../types";
 class LeadStateItem extends Item {
 	SchemaVersion!: string;
 	LeadId!: string;
+	LeadType!: string;
 	Status!: string;
 	UniversalRetailerId!: UUID;
-	LocationId!: UUID;
 	Lead!: Web2TextLead;
 	DateSubmitted!: Date;
 	Integrations!: Record<string, ExternalIntegrationState>;
@@ -18,6 +18,10 @@ const LeadStateModelTableName = `${ENV_PREFIX}_Web2Text_LeadStates`;
 const DynamoDBLeadStateSchema = new dynamoose.Schema(
 	{
 		SchemaVersion: {
+			type: String,
+			required: true,
+		},
+		LeadType: {
 			type: String,
 			required: true,
 		},
@@ -32,10 +36,6 @@ const DynamoDBLeadStateSchema = new dynamoose.Schema(
 			enum: ["ACTIVE", "SYNCING", "CLOSED"],
 		},
 		UniversalRetailerId: {
-			type: String,
-			required: true,
-		},
-		LocationId: {
 			type: String,
 			required: true,
 		},

--- a/modules/web2text/src/dynamodb/LeadStateModel.ts
+++ b/modules/web2text/src/dynamodb/LeadStateModel.ts
@@ -24,6 +24,7 @@ const DynamoDBLeadStateSchema = new dynamoose.Schema(
 		LeadType: {
 			type: String,
 			required: true,
+			default: "WEB2TEXT",
 		},
 		LeadId: {
 			type: String,

--- a/modules/web2text/src/dynamodb/OptedOutNumberModel.ts
+++ b/modules/web2text/src/dynamodb/OptedOutNumberModel.ts
@@ -2,7 +2,7 @@ import { ENV_PREFIX } from "common";
 import dynamoose from "dynamoose";
 import { Item } from "dynamoose/dist/Item";
 import type { E164Number } from "libphonenumber-js";
-import type { TwilioMessagingServiceBody } from "../restate/services/TwilioWebhooks";
+import type { TwilioMessagingServiceBody } from "../restate/services/TwilioWebhooks/TwilioWebhooks";
 
 class OptedOutNumberItem extends Item {
 	PhoneNumber!: E164Number;

--- a/modules/web2text/src/external/dhq/APIConverters.ts
+++ b/modules/web2text/src/external/dhq/APIConverters.ts
@@ -3,13 +3,13 @@ import type { DHQStoreInquiryAPI } from "common/external/dhq";
 import type { NexusStoresAPI } from "common/external/nexus";
 import type { MessageInstance } from "twilio/lib/rest/conversations/v1/conversation/message";
 import type { Jsonify } from "type-fest";
-import type { Web2TextLead } from "../../types";
+import type { SubmittedLeadState, Web2TextLead } from "../../types";
 
 export class Web2TextMessageIntoDhqComment extends Into<DHQStoreInquiryAPI.AddCommentRequest> {
 	private twilioMessage: Jsonify<MessageInstance>;
-	private web2TextLead: Web2TextLead;
+	private web2TextLead: SubmittedLeadState<Web2TextLead>;
 	constructor(
-		web2TextLead: Web2TextLead,
+		web2TextLead: SubmittedLeadState<Web2TextLead>,
 		twilioMessage: Jsonify<MessageInstance>,
 	) {
 		super();
@@ -41,10 +41,10 @@ export class Web2TextMessageIntoDhqComment extends Into<DHQStoreInquiryAPI.AddCo
 }
 
 export class Web2TextLeadIntoDHQStoreInquiry extends Into<DHQStoreInquiryAPI.StoreInquiryRequest> {
-	private web2TextLead: Web2TextLead;
+	private web2TextLead: SubmittedLeadState<Web2TextLead>;
 	private storeInfo: NexusStoresAPI.RetailerStore;
 	constructor(
-		web2TextLead: Web2TextLead,
+		web2TextLead: SubmittedLeadState<Web2TextLead>,
 		storeInfo: NexusStoresAPI.RetailerStore,
 	) {
 		super();

--- a/modules/web2text/src/external/dhq/DHQIntegration.ts
+++ b/modules/web2text/src/external/dhq/DHQIntegration.ts
@@ -8,7 +8,7 @@ import { NexusStoresAPI } from "common/external/nexus";
 import { isValidPhoneNumber } from "libphonenumber-js";
 import { serializeError } from "serialize-error";
 import type { Twilio } from "twilio";
-import type { LeadState, Web2TextLead } from "../../types";
+import type { SubmittedLeadState, Web2TextLead } from "../../types";
 import type { TwilioIntegrationState } from "../twilio/TwilioIntegration";
 import {
 	Web2TextLeadIntoDHQStoreInquiry,
@@ -21,7 +21,7 @@ interface DHQIntegrationState extends ExternalIntegrationState {
 	};
 }
 export class DHQIntegration extends IExternalIntegration<
-	LeadState,
+	SubmittedLeadState<Web2TextLead>,
 	DHQIntegrationState
 > {
 	Name = "DHQ";
@@ -38,20 +38,20 @@ export class DHQIntegration extends IExternalIntegration<
 	}
 	async create(
 		state: DHQIntegrationState,
-		context: ObjectSharedContext<Web2TextLead>,
+		context: ObjectSharedContext<SubmittedLeadState<Web2TextLead>>,
 	): Promise<DHQIntegrationState> {
 		const leadState = await context.getAll();
 		const store = await context.run(
 			"Fetch Store from Nexus",
 			async () =>
-				await NexusStoresAPI.GetRetailerStoreByID(leadState.LocationId),
+				await NexusStoresAPI.GetRetailerStoreByID(leadState.Lead.LocationId),
 		);
 		if (store === null) {
 			return {
 				...state,
 				SyncStatus: "ERROR",
 				ErrorInfo: {
-					Message: `Store '${leadState.LocationId}' does not exist in Nexus API`,
+					Message: `Store '${leadState.Lead.LocationId}' does not exist in Nexus API`,
 					ErrorDate: new Date(await context.date.now()).toISOString(),
 				},
 			};
@@ -96,7 +96,7 @@ export class DHQIntegration extends IExternalIntegration<
 	}
 	async sync(
 		state: DHQIntegrationState,
-		context: ObjectSharedContext<Web2TextLead>,
+		context: ObjectSharedContext<SubmittedLeadState<Web2TextLead>>,
 	): Promise<DHQIntegrationState> {
 		const lead = await context.getAll();
 		const twilioIntegration: TwilioIntegrationState | undefined =
@@ -168,7 +168,7 @@ export class DHQIntegration extends IExternalIntegration<
 	}
 	async close(
 		state: DHQIntegrationState,
-		context: ObjectSharedContext<Web2TextLead>,
+		context: ObjectSharedContext<SubmittedLeadState<Web2TextLead>>,
 	): Promise<DHQIntegrationState> {
 		return {
 			...state,

--- a/modules/web2text/src/external/index.ts
+++ b/modules/web2text/src/external/index.ts
@@ -3,13 +3,13 @@ import type {
 	IExternalIntegration,
 } from "common/external";
 import { TWILIO_CLIENT } from "../twilio";
-import type { LeadState } from "../types";
+import type { LeadState, SubmittedLeadState, Web2TextLead } from "../types";
 import { DHQIntegration } from "./dhq/DHQIntegration";
 import { RLMIntegration } from "./rlm/RLMIntegration";
 import { TwilioIntegration } from "./twilio/TwilioIntegration";
 
 export const Web2TextIntegrations: IExternalIntegration<
-	LeadState,
+	SubmittedLeadState<Web2TextLead>,
 	ExternalIntegrationState
 >[] = [
 	new TwilioIntegration(TWILIO_CLIENT),

--- a/modules/web2text/src/external/rlm/APIConverters.ts
+++ b/modules/web2text/src/external/rlm/APIConverters.ts
@@ -2,15 +2,15 @@ import { Into } from "common/external";
 import type { RLMLeadsAPI } from "common/external/rlm";
 import type { MessageInstance } from "twilio/lib/rest/conversations/v1/conversation/message";
 import type { Jsonify } from "type-fest";
-import type { Web2TextLead } from "../../types";
+import type { SubmittedLeadState, Web2TextLead } from "../../types";
 
 export class Web2TextMessageIntoRLMNote extends Into<RLMLeadsAPI.RLMAttachNoteRequest> {
 	private twilioMessage: Jsonify<MessageInstance>;
-	private web2TextLead: Web2TextLead;
+	private web2TextLead: SubmittedLeadState<Web2TextLead>;
 	private rlmLeadUUID: string;
 	constructor(
 		rlmLeadUUID: string,
-		web2TextLead: Web2TextLead,
+		web2TextLead: SubmittedLeadState<Web2TextLead>,
 		twilioMessage: Jsonify<MessageInstance>,
 	) {
 		super();
@@ -43,7 +43,7 @@ export class Web2TextMessageIntoRLMNote extends Into<RLMLeadsAPI.RLMAttachNoteRe
 }
 
 export class Web2TextLeadIntoRLMLead extends Into<RLMLeadsAPI.RLMCreateLeadRequest> {
-	private web2TextLead: Web2TextLead;
+	private web2TextLead: SubmittedLeadState<Web2TextLead>;
 	/**
 	 * The name of the location - RLM uses this to associated the lead with the correct location
 	 *
@@ -55,14 +55,14 @@ export class Web2TextLeadIntoRLMLead extends Into<RLMLeadsAPI.RLMCreateLeadReque
 	 */
 	private rlmLocationName: string;
 	constructor(
-		web2TextLead: Web2TextLead,
+		web2TextLead: SubmittedLeadState<Web2TextLead>,
 		rlmLocationName: string = "Per Pipeline configuration",
 	) {
 		super();
 		this.web2TextLead = web2TextLead;
 		this.rlmLocationName = rlmLocationName;
 	}
-	private static formatLeadIntoMessage(lead: Web2TextLead): string {
+	private static formatLeadIntoMessage(lead: SubmittedLeadState<Web2TextLead>): string {
 		let message = `--------------------
         Web2Text Lead Information
         --------------------

--- a/modules/web2text/src/external/rlm/RLMIntegration.ts
+++ b/modules/web2text/src/external/rlm/RLMIntegration.ts
@@ -8,7 +8,7 @@ import { RLMLeadsAPI, RLMLocationsAPI } from "common/external/rlm";
 import { isValidPhoneNumber } from "libphonenumber-js";
 import { serializeError } from "serialize-error";
 import type { Twilio } from "twilio";
-import type { LeadState, Web2TextLead } from "../../types";
+import type { LeadState, SubmittedLeadState, Web2TextLead } from "../../types";
 import type { TwilioIntegrationState } from "../twilio/TwilioIntegration";
 import {
 	Web2TextLeadIntoRLMLead,
@@ -25,7 +25,7 @@ export interface RLMIntegrationState extends ExternalIntegrationState {
 }
 
 export class RLMIntegration extends IExternalIntegration<
-	LeadState,
+	SubmittedLeadState<Web2TextLead>,
 	RLMIntegrationState
 > {
 	Name = "RLM";
@@ -55,7 +55,7 @@ export class RLMIntegration extends IExternalIntegration<
 	}
 	async create(
 		state: RLMIntegrationState,
-		context: restate.ObjectSharedContext<Web2TextLead>,
+		context: restate.ObjectSharedContext<SubmittedLeadState<Web2TextLead>>,
 	): Promise<RLMIntegrationState> {
 		const leadState = await context.getAll();
 		const retailer = await context.run(
@@ -77,11 +77,11 @@ export class RLMIntegration extends IExternalIntegration<
 		}
 		const rlmLocationMapping = await context.run(
 			"Get RLM location name",
-			async () => await this.getRLMLocationName(leadState.LocationId),
+			async () => await this.getRLMLocationName(leadState.Lead.LocationId),
 		);
 		if (rlmLocationMapping == null) {
 			context.console.warn(
-				`Could not find RLM location mapping for nexus location id: '${leadState.LocationId}'`,
+				`Could not find RLM location mapping for nexus location id: '${leadState.Lead.LocationId}'`,
 				{ _meta: 1, LeadState: leadState },
 			);
 		}
@@ -132,7 +132,7 @@ export class RLMIntegration extends IExternalIntegration<
 	}
 	async sync(
 		state: RLMIntegrationState,
-		context: restate.ObjectSharedContext<Web2TextLead>,
+		context: restate.ObjectSharedContext<SubmittedLeadState<Web2TextLead>>,
 	): Promise<RLMIntegrationState> {
 		const lead = await context.getAll();
 		const twilioIntegration: TwilioIntegrationState | undefined =
@@ -203,7 +203,7 @@ export class RLMIntegration extends IExternalIntegration<
 	}
 	async close(
 		state: RLMIntegrationState,
-		context: restate.ObjectSharedContext<Web2TextLead>,
+		context: restate.ObjectSharedContext<SubmittedLeadState<Web2TextLead>>,
 	): Promise<RLMIntegrationState> {
 		return {
 			...state,

--- a/modules/web2text/src/external/rlm/RLMIntegration.ts
+++ b/modules/web2text/src/external/rlm/RLMIntegration.ts
@@ -77,7 +77,7 @@ export class RLMIntegration extends IExternalIntegration<
 		}
 		const rlmLocationMapping = await context.run(
 			"Get RLM location name",
-			async () => await this.getRLMLocationName(leadState.Lead.LocationId),
+			async () => await this.getRLMLocationName(leadState.Lead.LocationId).catch(e => null),
 		);
 		if (rlmLocationMapping == null) {
 			context.console.warn(

--- a/modules/web2text/src/external/twilio/Web2TextMessagingStrings.ts
+++ b/modules/web2text/src/external/twilio/Web2TextMessagingStrings.ts
@@ -1,4 +1,4 @@
-import type { Web2TextLead } from "../../types";
+import type { SubmittedLeadState, Web2TextLead } from "../../types";
 
 export function SystemGreetingMessage(
 	dealerName: string,
@@ -7,7 +7,7 @@ export function SystemGreetingMessage(
 	return `Broadlume, a flooring software company, is facilitating this messaging conversation. We have connected you with ${dealerName}, and they will respond via ${contactPreference} shortly. Please text STOP to opt out of communication.`;
 }
 export function DealerGreetMessage(
-	lead: Web2TextLead,
+	lead: SubmittedLeadState<Web2TextLead>,
 	locationName: string,
 ): string {
 	let message = `You have a new Web2Text lead!

--- a/modules/web2text/src/restate/db.ts
+++ b/modules/web2text/src/restate/db.ts
@@ -2,10 +2,10 @@ import * as restate from "@restatedev/restate-sdk";
 import { GetRunningEnvironment } from "common";
 import { fromError } from "zod-validation-error";
 import { LeadStateModel } from "../dynamodb/LeadStateModel";
-import { type LeadState, Web2TextLeadSchema } from "../types";
+import { type LeadState, LeadStateSchema, type Web2TextLead, Web2TextLeadSchema } from "../types";
 
 export async function SyncWithDB(
-	ctx: restate.ObjectContext<LeadState>,
+	ctx: restate.ObjectContext<LeadState<Web2TextLead>>,
 	direction: "SEND" | "RECEIVE",
 ) {
 	ctx.console.debug(
@@ -16,7 +16,7 @@ export async function SyncWithDB(
 	switch (direction) {
 		case "SEND": {
 			const objectState = await ctx.getAll();
-			const parsed = Web2TextLeadSchema.parse(objectState);
+			const parsed = LeadStateSchema(Web2TextLeadSchema).parse(objectState);
 			// For debugging
 			if (GetRunningEnvironment().local) {
 				ctx.console.debug("SYNCED TO DB:", parsed);
@@ -40,7 +40,7 @@ export async function SyncWithDB(
 				break;
 			}
 			const { data, success, error } =
-				await Web2TextLeadSchema.safeParseAsync(lead);
+				await LeadStateSchema(Web2TextLeadSchema).safeParseAsync(lead);
 			if (!success) {
 				throw new restate.TerminalError(
 					`Could not parse lead ID '${leadID}' from database`,

--- a/modules/web2text/src/restate/db.ts
+++ b/modules/web2text/src/restate/db.ts
@@ -39,6 +39,13 @@ export async function SyncWithDB(
 				synced = false;
 				break;
 			}
+			// Schema migrations
+			if ("SchemaVersion" in lead && lead.SchemaVersion === "1.0.0") {
+				lead.Lead.LocationId = lead.LocationId;
+				delete lead.LocationId;
+				lead.LeadType = "WEB2TEXT";
+				lead.SchemaVersion = "2.0.0";
+			}
 			const { data, success, error } =
 				await LeadStateSchema(Web2TextLeadSchema).safeParseAsync(lead);
 			if (!success) {

--- a/modules/web2text/src/restate/services/Admin/AdminService.ts
+++ b/modules/web2text/src/restate/services/Admin/AdminService.ts
@@ -5,9 +5,9 @@ import { serializeError } from "serialize-error";
 import { assert, is } from "tsafe";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
-import { LeadStateModel } from "../../dynamodb/LeadStateModel";
-import type { Web2TextLead } from "../../types";
-import { LeadVirtualObject } from "./LeadVirtualObject";
+import { LeadStateModel } from "../../../dynamodb/LeadStateModel";
+import type { SubmittedLeadState, Web2TextLead } from "../../../types";
+import { LeadVirtualObject } from "../Lead/LeadVirtualObject";
 const NonEmptyObjectSchema = z
 	.object({})
 	.passthrough()
@@ -59,7 +59,7 @@ export const AdminService = restate.service({
 				// If Filter argument is an asterisk, filter for all Leads
 				// Otherwise use the filter object fields to filter the leads
 				const filter = parsed.data.Filter === "*" ? {} : parsed.data.Filter;
-				const leads: Web2TextLead[] = (await ctx.run(
+				const leads: SubmittedLeadState<Web2TextLead>[] = (await ctx.run(
 					"Scan LeadStates in DynamoDB",
 					async () => {
 						let scan: Scan<any>;
@@ -85,7 +85,7 @@ export const AdminService = restate.service({
 								);
 							});
 					},
-				)) as Web2TextLead[];
+				)) as SubmittedLeadState<Web2TextLead>[];
 				let result: any[] = [];
 				switch (parsed.data.Operation) {
 					case "CLOSE": {

--- a/modules/web2text/src/restate/services/Dealer/DealerVirtualObject.ts
+++ b/modules/web2text/src/restate/services/Dealer/DealerVirtualObject.ts
@@ -5,7 +5,8 @@ import { Authorization } from "common/restate";
 import parsePhoneNumber from "libphonenumber-js";
 import { assert, is } from "tsafe";
 import { z } from "zod";
-import { CheckClientStatus, CheckLocationStatus } from "../validators";
+import { CheckClientStatus, CheckLocationStatus } from "src/validators";
+
 
 type LocationStatus = {
 	NexusLocationId: string;

--- a/modules/web2text/src/restate/services/Dealer/DealerVirtualObject.ts
+++ b/modules/web2text/src/restate/services/Dealer/DealerVirtualObject.ts
@@ -5,7 +5,7 @@ import { Authorization } from "common/restate";
 import parsePhoneNumber from "libphonenumber-js";
 import { assert, is } from "tsafe";
 import { z } from "zod";
-import { CheckClientStatus, CheckLocationStatus } from "src/validators";
+import { CheckClientStatus, CheckLocationStatus } from "../../../validators";
 
 
 type LocationStatus = {

--- a/modules/web2text/src/restate/services/Lead/LeadVirtualObject.ts
+++ b/modules/web2text/src/restate/services/Lead/LeadVirtualObject.ts
@@ -97,6 +97,13 @@ export const LeadVirtualObject = restate.object({
 				// Run pre-handler setup
 				await setup(ctx, ["NONEXISTANT"]);
 				try {
+					// Schema migrations
+					if (req.SchemaVersion === "1.0.0") {
+						req.Lead.LocationId ??= req.LocationId;
+						delete req.LocationId;
+						req.LeadType ??= "WEB2TEXT";
+						req.SchemaVersion ??= "2.0.0";
+					}
 					// Parse the request
 					const leadCreateRequest = await Web2TextLeadCreateRequestSchema.safeParseAsync(req);
 					if (!leadCreateRequest.success) {

--- a/modules/web2text/src/restate/services/Lead/Web2TextLeadCreateRequest.ts
+++ b/modules/web2text/src/restate/services/Lead/Web2TextLeadCreateRequest.ts
@@ -1,4 +1,4 @@
-import { LeadStateSchema, Web2TextLeadSchema } from "src/types";
+import { LeadStateSchema, Web2TextLeadSchema } from "../../../types";
 import { z } from "zod";
 
 export const Web2TextLeadCreateRequestSchema =

--- a/modules/web2text/src/restate/services/Lead/Web2TextLeadCreateRequest.ts
+++ b/modules/web2text/src/restate/services/Lead/Web2TextLeadCreateRequest.ts
@@ -1,0 +1,16 @@
+import { LeadStateSchema, Web2TextLeadSchema } from "src/types";
+import { z } from "zod";
+
+export const Web2TextLeadCreateRequestSchema =
+    LeadStateSchema(Web2TextLeadSchema)
+        .options[1].omit({
+            Status: true,
+            LeadId: true,
+            DateSubmitted: true,
+            Integrations: true,
+            CloseReason: true,
+        })
+        .extend({
+            SyncImmediately: z.boolean().optional(),
+        });
+export type Web2TextLeadCreateRequest = z.infer<typeof Web2TextLeadCreateRequestSchema>;

--- a/modules/web2text/src/restate/services/TwilioWebhooks/TwilioWebhooks.ts
+++ b/modules/web2text/src/restate/services/TwilioWebhooks/TwilioWebhooks.ts
@@ -5,12 +5,9 @@ import parsePhoneNumber, { type E164Number } from "libphonenumber-js";
 import { assert, is } from "tsafe";
 import MessagingResponse from "twilio/lib/twiml/MessagingResponse";
 import { validateRequest } from "twilio/lib/webhooks/webhooks";
-import { OptedOutNumberModel } from "../../dynamodb/OptedOutNumberModel";
-import {
-	CustomerCloseMessage,
-	DealerCloseMessage,
-} from "../../external/twilio/Web2TextMessagingStrings";
-import { LeadVirtualObject } from "./LeadVirtualObject";
+import { OptedOutNumberModel } from "../../../dynamodb/OptedOutNumberModel";
+import { LeadVirtualObject } from "../Lead/LeadVirtualObject";
+import { CustomerCloseMessage, DealerCloseMessage } from "src/external/twilio/Web2TextMessagingStrings";
 
 interface TwilioWebhookBody {
 	AccountSid: string;

--- a/modules/web2text/src/restate/services/TwilioWebhooks/TwilioWebhooks.ts
+++ b/modules/web2text/src/restate/services/TwilioWebhooks/TwilioWebhooks.ts
@@ -7,7 +7,7 @@ import MessagingResponse from "twilio/lib/twiml/MessagingResponse";
 import { validateRequest } from "twilio/lib/webhooks/webhooks";
 import { OptedOutNumberModel } from "../../../dynamodb/OptedOutNumberModel";
 import { LeadVirtualObject } from "../Lead/LeadVirtualObject";
-import { CustomerCloseMessage, DealerCloseMessage } from "src/external/twilio/Web2TextMessagingStrings";
+import { CustomerCloseMessage, DealerCloseMessage } from "../../../external/twilio/Web2TextMessagingStrings";
 
 interface TwilioWebhookBody {
 	AccountSid: string;

--- a/modules/web2text/src/types.ts
+++ b/modules/web2text/src/types.ts
@@ -84,7 +84,7 @@ export function LeadStateSchema<T extends Record<string, any>, SCHEMA extends z.
 			 * Version of the Web2Text schema
 			 * Intended for DB migrations
 			 */
-			SchemaVersion: z.string().default("1.0.0"),
+			SchemaVersion: z.string().default("2.0.0"),
 			/**
 			 * The type of lead
 			 */

--- a/modules/web2text/src/types.ts
+++ b/modules/web2text/src/types.ts
@@ -22,121 +22,113 @@ const PhoneNumber = () =>
 
 export const Web2TextLeadSchema = z.object({
 	/**
-	 * Version of the Web2Text schema
-	 * Intended for DB migrations
-	 */
-	SchemaVersion: z.enum(["1.0.0"]).default("1.0.0"),
-	/**
-	 * The ID of the Lead
-	 */
-	LeadId: UUID(),
-	/**
-	 * The status of the lead
-	 * ACTIVE - The lead is active and has been synced to all its integrations
-	 * SYNCING - The lead is currently syncing to one or more of its integrations
-	 * CLOSED - The lead has been closed and is no longer syncing to its integrations
-	 */
-	Status: z.enum(["ACTIVE", "SYNCING", "CLOSED"]),
-	/**
-	 * If the lead is closed, the reason for why it was closed in human readable text
-	 */
-	CloseReason: z.string().optional(),
-	/**
-	 * The retailer this lead is associated with
-	 */
-	UniversalRetailerId: UUID(),
-	/**
 	 * The location this lead is associated with
 	 */
 	LocationId: UUID(),
-	Lead: z.object({
-		/**
-		 * The page the customer was on when submitting this lead
-		 */
-		PageUrl: NonEmptyString().url(),
-		/**
-		 * The IP address of the customer if it was able to be grabbed
-		 */
-		IPAddress: NonEmptyString().ip().optional(),
-		/**
-		 * The name of the customer
-		 */
-		Name: NonEmptyString(),
-		/**
-		 * The phone number of the customer
-		 */
-		PhoneNumber: PhoneNumber(),
-		/**
-		 * The customer's preferred method of contact
-		 */
-		PreferredMethodOfContact: z.enum(["phone", "text"]).default("text"),
-		/**
-		 * The customer's initial message for the dealer
-		 */
-		CustomerMessage: NonEmptyString(),
-		/**
-		 * If the customer was looking at a product - the details of that product
-		 */
-		AssociatedProductInfo: z
-			.object({
-				Brand: NonEmptyString(),
-				Product: NonEmptyString(),
-				Variant: NonEmptyString(),
-			})
-			.optional(),
-		/**
-		 * The Customer's Google Analytic traffic data at time of submission
-		 */
-		Traffic: z
-			.object({
-				Source: z.string().optional(),
-				Medium: z.string().optional(),
-				Campaign: z.string().optional(),
-				Content: z.string().optional(),
-				Term: z.string().optional(),
-				Type: z.string().optional(),
-			})
-			.optional(),
-	}),
 	/**
-	 * When the lead was submitted
+	 * The page the customer was on when submitting this lead
 	 */
-	DateSubmitted: z.coerce.string().datetime(),
+	PageUrl: NonEmptyString().url(),
 	/**
-	 * External integrations to sync this lead to
-	 * These are external systems that we can notify and sync leads with
+	 * The IP address of the customer if it was able to be grabbed
 	 */
-	Integrations: z.record(z.string(), ExternalIntegrationStateSchema),
+	IPAddress: NonEmptyString().ip().optional(),
+	/**
+	 * The name of the customer
+	 */
+	Name: NonEmptyString(),
+	/**
+	 * The phone number of the customer
+	 */
+	PhoneNumber: PhoneNumber(),
+	/**
+	 * The customer's preferred method of contact
+	 */
+	PreferredMethodOfContact: z.enum(["phone", "text"]).default("text"),
+	/**
+	 * The customer's initial message for the dealer
+	 */
+	CustomerMessage: NonEmptyString(),
+	/**
+	 * If the customer was looking at a product - the details of that product
+	 */
+	AssociatedProductInfo: z
+		.object({
+			Brand: NonEmptyString(),
+			Product: NonEmptyString(),
+			Variant: NonEmptyString(),
+		})
+		.optional(),
+	/**
+	 * The Customer's Google Analytic traffic data at time of submission
+	 */
+	Traffic: z
+		.object({
+			Source: z.string().optional(),
+			Medium: z.string().optional(),
+			Campaign: z.string().optional(),
+			Content: z.string().optional(),
+			Term: z.string().optional(),
+			Type: z.string().optional(),
+		})
+		.optional(),
 });
 
-export const Web2TextLeadCreateRequestSchema = Web2TextLeadSchema.omit({
-	Status: true,
-	LeadId: true,
-	DateSubmitted: true,
-	Integrations: true,
-	CloseReason: true,
-}).extend({
-	SyncImmediately: z.boolean().optional(),
-});
-
-export const LeadStateSchema = z.discriminatedUnion("Status", [
-	z.object({
-		Status: z.literal("NONEXISTANT"),
-	}),
-	z.object({
-		Status: z.literal("VALIDATING"),
-		Request: z.unknown(),
-	}),
-	Web2TextLeadSchema,
-	z.object({
-		Status: z.literal("ERROR"),
-		Error: z.any(),
-		Request: z.unknown(),
-	}),
-]);
-export type LeadState = z.infer<typeof LeadStateSchema>;
-
+export function LeadStateSchema<T extends Record<string, any>, SCHEMA extends z.ZodType<T> = z.ZodType<T>>(leadSchema: SCHEMA) {
+	return z.discriminatedUnion("Status", [
+		z.object({
+			Status: z.literal("NONEXISTANT"),
+		}),
+		z.object({
+			/**
+			 * Version of the Web2Text schema
+			 * Intended for DB migrations
+			 */
+			SchemaVersion: z.string().default("1.0.0"),
+			/**
+			 * The type of lead
+			 */
+			LeadType: z.enum(["WEB2TEXT"]).default("WEB2TEXT"),
+			/**
+			 * The status of the lead
+			 * ACTIVE - The lead is active and has been synced to all its integrations
+			 * SYNCING - The lead is currently syncing to one or more of its integrations
+			 * CLOSED - The lead has been closed and is no longer syncing to its integrations
+			 */
+			Status: z.enum(["ACTIVE", "SYNCING", "CLOSED"]),
+			/**
+			 * The ID of the Lead
+			 */
+			LeadId: UUID(),
+			/**
+			 * If the lead is closed, the reason for why it was closed in human readable text
+			 */
+			CloseReason: z.string().optional(),
+			/**
+			 * The retailer this lead is associated with
+			 */
+			UniversalRetailerId: UUID(),
+			/**
+			 * The lead data
+			 */
+			Lead: leadSchema,
+			/**
+			 * When the lead was submitted
+			 */
+			DateSubmitted: z.coerce.string().datetime(),
+			/**
+			 * External integrations to sync this lead to
+			 */
+			Integrations: z.record(z.string(), ExternalIntegrationStateSchema),
+		}),
+		z.object({
+			Status: z.literal("ERROR"),
+			Error: z.any(),
+			Request: z.unknown(),
+		}).passthrough(),
+	]);
+}
+export type LeadState<T extends Record<string, any>> = z.infer<ReturnType<typeof LeadStateSchema<T>>>;
+export type SubmittedLeadState<T extends Record<string, any>> = LeadState<T> & { Status: "ACTIVE" | "SYNCING" | "CLOSED" };
+export type ErrorLeadState<T extends Record<string, any>> = LeadState<T> & { Status: "ERROR" };
 export type Web2TextLead = z.infer<typeof Web2TextLeadSchema>;
-export type Web2TextLeadCreateRequest = z.infer<
-	typeof Web2TextLeadCreateRequestSchema
->;


### PR DESCRIPTION
This PR:
- Decouples Web2Text's lead state
    - Makes the lead handling more generic over the fields that it syncs
- Remove `VALIDATING` state (it was never externally visible)
- Move `LocationId` into the `Lead` object
- Add `LeadType` field